### PR TITLE
PyTorch + Dockerfile Update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ['3.8', '3.9']
+        python-version: ['3.11', '3.12']
     defaults:
       run:
         shell: bash -l {0}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@ FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 
 WORKDIR /usr/src/app
 
-# Install micromamba
-RUN apt-get update && apt-get install -y curl bzip2 git && \
-    curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xj -C /usr/local/bin --strip-components=1 bin/micromamba && \
+# Install dependencies and micromamba
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl bzip2 git ca-certificates && \
+    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | \ 
+    tar -xj -C /usr/local/bin --strip-components=1 bin/micromamba && \
+    # Clean up apt caches
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Use only conda-forge
@@ -24,7 +28,7 @@ RUN echo 'eval "$(/usr/local/bin/micromamba shell hook --shell bash)"' >> /root/
 ENV PATH="/opt/conda/envs/delfta/bin:$PATH"
 
 # Clone the delfta repository and install it
-RUN git clone -b pytorch-update https://github.com/janash/delfta.git
+RUN git clone --depth 1 https://github.com/josejimenezluna/delfta.git
 
 RUN cd delfta && \
     pip install -e . && \
@@ -34,5 +38,4 @@ RUN cd delfta && \
 RUN cd delfta && \
     micromamba run -n delfta python -c "import runpy; _ = runpy.run_module('delfta.download', run_name='__main__')"
 
-# Remove ENTRYPOINT to allow direct shell access with environment activated
 CMD ["/bin/bash", "-l"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,38 @@
-FROM gpuci/miniconda-cuda:11.2-devel-ubuntu20.04
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
+
 WORKDIR /usr/src/app
 
-# install delfta
-RUN git clone https://github.com/josejimenezluna/delfta.git
+# Install micromamba
+RUN apt-get update && apt-get install -y curl bzip2 git && \
+    curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xj -C /usr/local/bin --strip-components=1 bin/micromamba && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN cd delfta && make
-RUN conda init
-RUN echo 'conda activate delfta' >> ~/.bashrc
+# Use only conda-forge
+ENV MAMBA_NO_BANNER=1
+ENV MAMBA_ROOT_PREFIX=/opt/conda
+
+# Create env
+COPY environment.yml .
+RUN micromamba create -y -n delfta -f environment.yml && \
+    micromamba clean -a -y
+
+# Add micromamba activation to .bashrc so it's available in interactive shells
+RUN echo 'eval "$(/usr/local/bin/micromamba shell hook --shell bash)"' >> /root/.bashrc && \
+    echo 'micromamba activate delfta' >> /root/.bashrc
+
+# Make sure PATH includes the micromamba bin directory
+ENV PATH="/opt/conda/envs/delfta/bin:$PATH"
+
+# Clone the delfta repository and install it
+RUN git clone -b pytorch-update https://github.com/janash/delfta.git
+
+RUN cd delfta && \
+    pip install -e . && \
+    rm -rf /root/.cache/pip
+
+# Download module data
+RUN cd delfta && \
+    micromamba run -n delfta python -c "import runpy; _ = runpy.run_module('delfta.download', run_name='__main__')"
+
+# Remove ENTRYPOINT to allow direct shell access with environment activated
+CMD ["/bin/bash", "-l"]

--- a/delfta/calculator.py
+++ b/delfta/calculator.py
@@ -8,9 +8,10 @@ import pickle
 import types
 
 import numpy as np
-import openbabel
+from openbabel import openbabel
+from openbabel import pybel
 import torch
-from torch_geometric.data.dataloader import DataLoader
+from torch_geometric.loader import DataLoader
 from tqdm import tqdm
 
 from delfta.download import MODELS, get_model_weights
@@ -500,7 +501,7 @@ class DelftaCalculator:
         fatal_xtb, fatal = [], []
         xtb_all_fail = False
 
-        if isinstance(input_, openbabel.pybel.Molecule):
+        if isinstance(input_, pybel.Molecule):
             return self.predict([input_])
 
         elif isinstance(input_, list):

--- a/delfta/calculator.py
+++ b/delfta/calculator.py
@@ -520,7 +520,7 @@ class DelftaCalculator:
 
         elif isinstance(input_, str):
             ext = os.path.splitext(input_)[-1].lstrip(".")
-            return self.predict(openbabel.pybel.readfile(ext, input_))
+            return self.predict(pybel.readfile(ext, input_))
 
         else:
             raise ValueError(

--- a/delfta/net.py
+++ b/delfta/net.py
@@ -284,11 +284,11 @@ class EGNN_sparse(MessagePassing):
 
     def propagate(self, edge_index: Adj, size: Size = None, **kwargs):
         # get input tensors
-        size = self.__check_input__(edge_index, size)
-        coll_dict = self.__collect__(self.__user_args__, edge_index, size, kwargs)
-        msg_kwargs = self.inspector.distribute("message", coll_dict)
-        aggr_kwargs = self.inspector.distribute("aggregate", coll_dict)
-        update_kwargs = self.inspector.distribute("update", coll_dict)
+        size = self._check_input(edge_index, size)
+        coll_dict = self._collect(self._user_args, edge_index, size, kwargs)
+        msg_kwargs = self.inspector.collect_param_data("message", coll_dict)
+        aggr_kwargs = self.inspector.collect_param_data("aggregate", coll_dict)
+        update_kwargs = self.inspector.collect_param_data("update", coll_dict)
 
         # get messages
         m_ij = self.message(**msg_kwargs)
@@ -531,9 +531,9 @@ class EGNN_sparse_edge(MessagePassing):
     def propagate(self, edge_index: Adj, size: Size = None, **kwargs):
 
         # get input tensors
-        size = self.__check_input__(edge_index, size)
-        coll_dict = self.__collect__(self.__user_args__, edge_index, size, kwargs)
-        msg_kwargs = self.inspector.distribute("message", coll_dict)
+        size = self._check_input(edge_index, size)
+        coll_dict = self._collect(self._user_args, edge_index, size, kwargs)
+        msg_kwargs = self.inspector.collect_param_data("message", coll_dict)
 
         # get messages
         m_ij = self.message(**msg_kwargs)
@@ -547,10 +547,10 @@ class EGNN_sparse_edge(MessagePassing):
         edge_index = torch.cat([edge_index, edge_mirrored], dim=1)
 
         # update dict with new edge ids
-        size = self.__check_input__(edge_index, size)
-        coll_dict = self.__collect__(self.__user_args__, edge_index, size, kwargs)
-        aggr_kwargs = self.inspector.distribute("aggregate", coll_dict)
-        update_kwargs = self.inspector.distribute("update", coll_dict)
+        size = self._check_input(edge_index, size)
+        coll_dict = self._collect(self._user_args, edge_index, size, kwargs)
+        aggr_kwargs = self.inspector.collect_param_data("aggregate", coll_dict)
+        update_kwargs = self.inspector.collect_param_data("update", coll_dict)
 
         # aggregate messages
         m_i = self.aggregate(m_ij_mirrored, **aggr_kwargs)

--- a/environment.yml
+++ b/environment.yml
@@ -1,26 +1,24 @@
 name: delfta
 channels:
-  - pytorch
-  - defaults
-  - rusty1s
   - conda-forge
+
 dependencies:
-  - joblib=1.0.1
-  - matplotlib=3.3.2
-  - numpy=1.19.2
-  - pandas=1.1.3
-  - pip=20.2.4
-  - scikit-learn=0.23.2
-  - scipy=1.5.2
-  - tqdm=4.51.0
-  - pytorch=1.8.0
-  - pytorch-geometric=1.7.2
-  - cudatoolkit=10.2
-  - openbabel=3.1.1
-  - h5py=3.2.1
-  - xtb=6.3.1
-  - einops=0.3.0
+  - python
+  - pytorch
+  - pytorch_geometric
+  - torch-scatter
+  - openbabel
+  - xtb=6.3.1 # pin for delfta compatibility
+  - h5py
+  - numpy
+  - pandas
+  - scikit-learn
+  - scipy
+  - matplotlib
+  - tqdm
+  - joblib
+  - einops
+  - pip
   - pip:
-    - ase==3.21.1
-    - einops==0.3.0
-    - networkx==2.5
+      - ase
+      - networkx

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - joblib
   - einops
   - pip
+  - pytest 
   - pip:
       - ase
       - networkx

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,7 +1,7 @@
 from delfta.net import EGNN
 from delfta.net_utils import MODEL_HPARAMS, DelftaDataset
 from openbabel.pybel import readstring
-from torch_geometric.data.dataloader import DataLoader
+from torch_geometric.loader import DataLoader
 
 
 def test_net_outshape():


### PR DESCRIPTION
While attempting to run some calculations with this model, I ran into the problem that the CUDA version in the Docker container is too old (I believe it is v 11, while most GPUs will now have v 12). While upgrading the Dockerfile so that I can run it using GPUs, I also found that the PyTorch version is too old for CUDA v12.

This PR updates the code to be compatible with PyTorch 2.6.0 (was using PyTorch 1.8.0 in older container) and updates the `environment.yml` and the Dockerfile to build with CUDA 12.2 (`nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04`). **Note** The Dockerfile currently points at my fork/branch when cloning delfta. This would need to be changed before merging.

I've been able to successfully run calculations with these changes, but more thorough testing may be needed.